### PR TITLE
adding the touchAfter feature to allow lazy updates on database

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -195,10 +195,10 @@ app.use(session({
 }));
 ```
 
-### Enable lazy session update
+### Lazy session update
 
 
-If you are using [express-session](https://github.com/expressjs/session) >= [1.10.0](https://github.com/expressjs/session/releases/tag/v1.10.0) and don't want to update the expires property on database every single time that the user refresh the page, you can lazy update the session, by limiting how many updates you want to be made in a period of time.
+If you are using [express-session](https://github.com/expressjs/session) >= [1.10.0](https://github.com/expressjs/session/releases/tag/v1.10.0) and don't want to resave all the session on database every single time that the user refresh the page, you can lazy update the session, by limiting a period of time.
 
 ```js
 app.use(express.session({
@@ -207,29 +207,12 @@ app.use(express.session({
 	resave: false, //don't save session if unmodified
 	store: new mongoStore({
 		url: 'mongodb://localhost/test-app',
-		touchAfter: 24 * 3600000, // time period in ms
-		serialize: function (session) {
-            var obj = {};
-            obj.lastModified = Date.now();
-            obj.cookie = session.cookie.toJSON ? session.cookie.toJSON() : session.cookie;
-            obj = JSON.stringify(obj);
-            return obj;
-        },
-        unserialize: function (session) {
-            return JSON.parse(session);
-        }
+		touchAfter: 24 * 3600000 // time period in ms
 	})
 }));
 ```
 
-by doing this, setting `touchAfter: 24 * 3600000` you are saying to the session be updated only one time in a period of 24 hours, does not matter how many request's are made (with the exception of those that update something on the session data)
-
-If you want to use this feature, remember this:
-
-1. the property `touchAfter` must be **numeric**
-2. you should pass a custom `serialize` function that set a field called **lastModified** with the current timestamp and a custom `unserialize` function
-
-__Note:__ this feature only works in session modules that implements the req.session.touch() interface (like express-session >= [1.10.0](https://github.com/expressjs/session/releases/tag/v1.10.0)
+by doing this, setting `touchAfter: 24 * 3600000` you are saying to the session be updated only one time in a period of 24 hours, does not matter how many request's are made (with the exception of those that change something on the session data)
 
 ## More options
 

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -353,20 +353,35 @@ module.exports = function(connect) {
    * @api public
    */
   MongoStore.prototype.touch = function (sid, session, callback) {
+
+    var updateFields = {};
+
+    if(this.options.updateAfter){
+
+      var timeElapsed = Date.now() - session.lastModified;
+
+      if(timeElapsed < this.options.updateAfter){
+        return callback();
+      } else {
+        updateFields.session = session;
+        updateFields.session.lastModified = Date.now();
+        updateFields.session = JSON.stringify(updateFields.session);
+      }
+
+    }
+
     if (!callback) callback = _.noop;
     sid = this.getSessionId(sid);
 
-    var expires;
-
     if (session && session.cookie && session.cookie.expires) {
-      expires = new Date(session.cookie.expires);
+      updateFields.expires = new Date(session.cookie.expires);
     } else {
-      expires = new Date(Date.now() + this.options.ttl * 1000);
+      updateFields.expires = new Date(Date.now() + this.options.ttl * 1000);
     }
 
     this.getCollection(function(err, collection) {
       if (err) return callback(err);
-      collection.update({ _id: sid }, { $set: { expires: expires } }, { safe: true }, function (err, result) {
+      collection.update({ _id: sid }, { $set: updateFields }, { safe: true }, function (err, result) {
         if (err) {
           debug('not able to touch session: %s (error)', sid);
           callback(err);

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -288,6 +288,9 @@ module.exports = function(connect) {
           var s;
           try {
             s = self.options.unserialize(session.session);
+            if(self.options.touchAfter > 0 && session.lastModified){
+              s.lastModified = session.lastModified;
+            }
           } catch (err) {
             debug('unable to deserialize session');
             callback(err);
@@ -335,6 +338,10 @@ module.exports = function(connect) {
       s.expires = new Date(Date.now() + this.options.ttl * 1000);
     }
 
+    if(this.options.touchAfter > 0){
+      s.lastModified = new Date();
+    }
+
     this.getCollection(function(err, collection) {
       if (err) return callback(err);
       collection.update({_id: sid}, s, {upsert: true, safe: true}, function(err) {
@@ -356,8 +363,8 @@ module.exports = function(connect) {
 
     var updateFields = {},
       touchAfter = this.options.touchAfter,
-      lastModified = session.lastModified,
-      now = Date.now();
+      lastModified = session.lastModified ? session.lastModified.getTime() : 0,
+      currentDate = new Date();
 
     sid = this.getSessionId(sid);
 
@@ -368,14 +375,12 @@ module.exports = function(connect) {
     // the specified, if it's not, don't touch the session
     if(touchAfter > 0 && lastModified > 0){
 
-      var timeElapsed = now - session.lastModified;
+      var timeElapsed = currentDate.getTime() - session.lastModified;
 
       if(timeElapsed < touchAfter){
         return callback();
       } else {
-        updateFields.session = session;
-        updateFields.session.lastModified = now;
-        updateFields.session = JSON.stringify(updateFields.session);
+        updateFields.lastModified = currentDate;
       }
 
     }

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -354,24 +354,30 @@ module.exports = function(connect) {
    */
   MongoStore.prototype.touch = function (sid, session, callback) {
 
-    var updateFields = {};
+    var updateFields = {},
+      sid = this.getSessionId(sid), 
+      touchAfter = this.options.touchAfter,
+      lastModified = session.lastModified,
+      now = Date.now();
 
-    if(this.options.updateAfter){
+    callback = callback ? callback : _.noop;
 
-      var timeElapsed = Date.now() - session.lastModified;
+    // if the given options has a touchAfter property, check if the
+    // current timestamp - lastModified timestamp is bigger than 
+    // the specified, if it's not, don't touch the session
+    if(touchAfter > 0 && lastModified > 0){
 
-      if(timeElapsed < this.options.updateAfter){
+      var timeElapsed = now - session.lastModified;
+
+      if(timeElapsed < touchAfter){
         return callback();
       } else {
         updateFields.session = session;
-        updateFields.session.lastModified = Date.now();
+        updateFields.session.lastModified = now;
         updateFields.session = JSON.stringify(updateFields.session);
       }
 
     }
-
-    if (!callback) callback = _.noop;
-    sid = this.getSessionId(sid);
 
     if (session && session.cookie && session.cookie.expires) {
       updateFields.expires = new Date(session.cookie.expires);

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -355,10 +355,11 @@ module.exports = function(connect) {
   MongoStore.prototype.touch = function (sid, session, callback) {
 
     var updateFields = {},
-      sid = this.getSessionId(sid), 
       touchAfter = this.options.touchAfter,
       lastModified = session.lastModified,
       now = Date.now();
+
+    sid = this.getSessionId(sid);
 
     callback = callback ? callback : _.noop;
 

--- a/test/connect-mongo.test.js
+++ b/test/connect-mongo.test.js
@@ -811,9 +811,7 @@ exports.test_session_lazy_touch_simultaneously = function(done) {
   open_db(lazyOptions, function(store, db, collection) {
 
     var sid = 'test_lazy_touch-sid',
-      data = make_data(),
-      lastModifiedBeforeTouch,
-      lastModifiedAfterTouch;
+      data = make_data();
 
     store.set(sid, data, function(err) {
       assert.equal(err, null);
@@ -834,7 +832,7 @@ exports.test_session_lazy_touch_simultaneously = function(done) {
             assert.equal(err, null);
 
             session2 = JSON.parse(session2.session);
-            lastModifiedAfterTouch = session2.lastModified;
+            var lastModifiedAfterTouch = session2.lastModified;
 
             assert.strictEqual(lastModifiedBeforeTouch, lastModifiedAfterTouch)
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---ui exports
+--ui exports --timeout 6000


### PR DESCRIPTION
The purpose of this feature is improve the performance of updates on database by limiting the number of updates that are made in a period of time.

Exemple:

1) users can refresh the page 5 times repeatedly due to a slow internet connection, and this will make 5 updates on database.

2) users can navigate in 50 pages in less than 10 minutes and this will make 50 updates on database.

Note: the tests are taking 3 seconds to run due to an async test of this feature.