### PR TITLE
removing the lastModified prop from the session object before update

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -323,6 +323,11 @@ module.exports = function(connect) {
     if (!callback) callback = _.noop;
     sid = this.getSessionId(sid);
 
+    // removing the lastModified prop from the session object before update
+    if(this.options.touchAfter > 0 && session && session.lastModified){
+      delete session.lastModified;
+    }
+
     var s;
 
     try {


### PR DESCRIPTION
I just realized that I was accidentally setting the `lastModified` prop at the session object, this commit solve this mistake.