### PR TITLE
Fix native driver events order

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -204,10 +204,17 @@ module.exports = function(connect) {
     function initWithNativeDb() {
       self.db = options.db;
 
-      if (options.db.openCalled) {
-        options.db.collection(options.collection, connectionReady);
+      if (options.db.openCalled !== undefined) {
+        if (options.db.openCalled) {
+          options.db.collection(options.collection, connectionReady);
+        } else {
+          options.db.open(connectionReady);
+        }
       } else {
-        options.db.open(connectionReady);
+        // mongo-native-driver@2.0 has no Db.openCalled property
+        process.nextTick(function () {
+          options.db.collection(options.collection, connectionReady);
+        });
       }
     }
 

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -204,17 +204,10 @@ module.exports = function(connect) {
     function initWithNativeDb() {
       self.db = options.db;
 
-      if (options.db.openCalled !== undefined) {
-        if (options.db.openCalled) {
-          options.db.collection(options.collection, connectionReady);
-        } else {
-          options.db.open(connectionReady);
-        }
+      if (options.db.openCalled) {
+        options.db.collection(options.collection, connectionReady);
       } else {
-        // mongo-native-driver@2.0 has no Db.openCalled property
-        process.nextTick(function () {
-          options.db.collection(options.collection, connectionReady);
-        });
+        options.db.open(connectionReady);
       }
     }
 
@@ -252,7 +245,7 @@ module.exports = function(connect) {
       initWithMongooseConnection();
     } else if (options.db && options.db instanceof Db) {
       debug('use strategy: `native_db`');
-      initWithNativeDb();
+      process.nextTick(initWithNativeDb);
     } else {
       debug('use strategy: `legacy`');
       buildUrlFromOptions();


### PR DESCRIPTION
Db.open() doesn't run callback in my case.

UPD: I am not right. The problem appears even in native driver @ 1.x, when my connection string is `mongodb://127.0.0.1:27017/users`
```
  connect-mongo switched to state: init +0ms
  connect-mongo use strategy: `native_db` +1ms
  connect-mongo switched to state: connected +1ms
  connect-mongo switched to state: connecting +0ms
```

UPD: In Mongo@2.x driver db.openCalled is undefined and db.open(callback) doesn't fire callback at all, so we can act like the connection is already established. Therefore fix by @barisusakli works nice with this PR: https://github.com/kcbanner/connect-mongo/issues/161#issuecomment-79466714