### PR TITLE
[WIP] Respect missing openCalled property in mongodb@2.x

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -204,7 +204,7 @@ module.exports = function(connect) {
     function initWithNativeDb() {
       self.db = options.db;
 
-      if (options.db.openCalled) {
+      if (options.db.openCalled || options.db.openCalled !== undefined) { // openCalled is undefined in mongodb@2.x
         options.db.collection(options.collection, connectionReady);
       } else {
         options.db.open(connectionReady);

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -204,7 +204,7 @@ module.exports = function(connect) {
     function initWithNativeDb() {
       self.db = options.db;
 
-      if (options.db.openCalled || options.db.openCalled !== undefined) { // openCalled is undefined in mongodb@2.x
+      if (options.db.openCalled || options.db.openCalled === undefined) { // openCalled is undefined in mongodb@2.x
         options.db.collection(options.collection, connectionReady);
       } else {
         options.db.open(connectionReady);


### PR DESCRIPTION
mongodb@2.x doesn't have openCalled property, and it's okay not to call db.open() directly.
https://github.com/kcbanner/connect-mongo/issues/161#issuecomment-88224772

`make test` runs okay on my local computer
Failing test is really weird