### PR TITLE
Removed `throw err` and added `self.emit('error')` so you can listen to it on db error

### DIFF
--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -13,7 +13,6 @@ var deprecate = require('depd')('connect-mongo');
 var MongoClient = mongo.MongoClient;
 var Db = mongo.Db;
 
-
 /**
  * Default options
  */
@@ -131,7 +130,8 @@ module.exports = function(connect) {
       if (err) {
           debug('not able to connect to the database');
           changeState('disconnected');
-          throw err;
+          self.emit('error', err);
+          return err;
       }
 
       self.collection = self.db.collection(options.collection);
@@ -261,6 +261,7 @@ module.exports = function(connect) {
    */
    util.inherits(MongoStore, Store);
 
+
   /**
    * Attempt to fetch session by the given `sid`.
    *
@@ -383,7 +384,7 @@ module.exports = function(connect) {
     callback = callback ? callback : _.noop;
 
     // if the given options has a touchAfter property, check if the
-    // current timestamp - lastModified timestamp is bigger than 
+    // current timestamp - lastModified timestamp is bigger than
     // the specified, if it's not, don't touch the session
     if(touchAfter > 0 && lastModified > 0){
 


### PR DESCRIPTION
Removed `throw err` and added `self.emit('error')` so you can listen to it on MongoStore when mongod is not running or not accessible (db error). See diff, two line change. Now, we can do:

`var store = new MongoStore(...);`
`store.on('error', function(){ ... });`