### PR TITLE
Added eventEmitters option for get(), set() and destroy() functions.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -218,6 +218,7 @@ by doing this, setting `touchAfter: 24 * 3600` you are saying to the session be 
 
   - `collection` Collection (default: `sessions`)
   - `fallbackMemory` Fallback to `MemoryStore`. Useful if you want to use MemoryStore in some case, like in development environment.
+  - `eventEmitters` If true, everytime set(), destroy() or get() is called, they will emit events 'set', 'destroy' or 'get' respectively.
   - `stringify` If true, connect-mongo will serialize sessions using `JSON.stringify` before
                 setting them, and deserialize them with `JSON.parse` when getting them.
                 (optional, default: true). This is useful if you are using types that

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -24,6 +24,7 @@ var defaultOptions = {
   autoReconnect: true,
   ssl: false,
   w: 1,
+  eventEmitters: false,
 
   // Global options
   collection: 'sessions',
@@ -302,7 +303,9 @@ module.exports = function(connect) {
             debug('unable to deserialize session');
             callback(err);
           }
-          this.emit('touch');
+          if(self.options.eventEmitters){
+            this.emit('touch');
+          }
           callback(null, s);
         } else {
           callback();
@@ -360,7 +363,9 @@ module.exports = function(connect) {
       collection.update({_id: sid}, s, {upsert: true, safe: true}, function(err) {
         if (err) {debug('not able to set/update session: ' + sid);}
         else {
-          this.emit('set');
+          if(self.options.eventEmitters){
+            this.emit('set');
+          }
         }
         callback(err);
       });
@@ -440,7 +445,9 @@ module.exports = function(connect) {
         if (err) {
           debug('not able to destroy session: ' + sid);
         }else {
-          this.emit('destroy');
+          if(self.options.eventEmitters){
+            this.emit('destroy');
+          }
         }
         callback(err);
       });

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -302,6 +302,7 @@ module.exports = function(connect) {
             debug('unable to deserialize session');
             callback(err);
           }
+          this.emit('touch');
           callback(null, s);
         } else {
           callback();

--- a/lib/connect-mongo.js
+++ b/lib/connect-mongo.js
@@ -357,7 +357,10 @@ module.exports = function(connect) {
     this.getCollection(function(err, collection) {
       if (err) return callback(err);
       collection.update({_id: sid}, s, {upsert: true, safe: true}, function(err) {
-        if (err) debug('not able to set/update session: ' + sid);
+        if (err) {debug('not able to set/update session: ' + sid);}
+        else {
+          this.emit('set');
+        }
         callback(err);
       });
     });
@@ -433,7 +436,11 @@ module.exports = function(connect) {
     this.getCollection(function(err, collection) {
       if (err) return callback(err);
       collection.remove({_id: sid}, function(err) {
-        if (err) debug('not able to destroy session: ' + sid);
+        if (err) {
+          debug('not able to destroy session: ' + sid);
+        }else {
+          this.emit('destroy');
+        }
         callback(err);
       });
     });


### PR DESCRIPTION
I thought this would be useful as I've been using it for my own project. Since sessionStore inherits from EventEmitters, I thought I would add events for the get(), set() and destroy() functions.

See https://stackoverflow.com/questions/7762299/how-can-i-add-an-event-listener-to-a-session-redis-with-nodejs-and-express for context.