### PR TITLE
Send Set-Cookie header on .touch()

### DIFF
--- a/src/connect-mongo.js
+++ b/src/connect-mongo.js
@@ -260,13 +260,13 @@ export default function connectMongo(connect) {
                 if(timeElapsed < touchAfter){
                     return callback();
                 } else {
-                    updateFields.lastModified = currentDate;
+                    updateFields.lastModified = session.lastModified = currentDate;
                 }
 
             }
 
             if (session && session.cookie && session.cookie.expires) {
-                updateFields.expires = new Date(session.cookie.expires);
+                updateFields['session.cookie.expires'] = updateFields.expires = new Date(session.cookie.expires);
             } else {
                 updateFields.expires = new Date(Date.now() + this.options.ttl * 1000);
             }


### PR DESCRIPTION
As proposed in this change during the touch the actual session object is not changed - changes are only made to data stored in mongodb.
Express-session middleware computes CRC hash bases on stringified JSON representation of session object.
If the originalHash and modifiedHash are equal, then Set-Cookie header is not sent to the browser, the browser will not know if we have touched the session or not and it will trash the cookie with sessionID based on original expires. This fix modifies also the session.lastModified key so the CRC will change and a Set-Cookie header will be issued to the browser.