### PR TITLE
Added .close operation to MongoStore.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -300,6 +300,9 @@ module.exports = function connectMongo(connect) {
                 .nodeify(callback);
         }
 
+        close() {
+            this.db.close();
+        }
     }
 
     return MongoStore;

--- a/src/index.js
+++ b/src/index.js
@@ -301,7 +301,9 @@ module.exports = function connectMongo(connect) {
         }
 
         close() {
-            this.db.close();
+            if (this.db) {
+                this.db.close();
+            }
         }
     }
 


### PR DESCRIPTION
Scenario: When running unit tests via Gulp that leverage MongoStore/connect-mongo, the lingering this.db instance remains open, preventing the node process from terminating. 

Workaround: Users have to currently manually reach inside the MongoStore and call instance.db.close(). 

This pull request adds a simple .close() operation that allows for manual disposal of the MongoStore.